### PR TITLE
Make SyncState type nullable

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -72,25 +72,37 @@ const BUFFER_PERIOD_MS = 80 * 1000;
 // keepAlive is successful but the server /sync fails.
 const FAILED_SYNC_ERROR_THRESHOLD = 3;
 
-export enum SyncState {
+// Q: This definition looks like an enum - why not use an enum for SyncState?
+// A: `null` is a valid subtype of `SyncState`; TypeScript enums with values do
+// not support a case with a null value.
+export type SyncState =
+    | "ERROR"
+    | "PREPARED"
+    | "STOPPED"
+    | "SYNCING"
+    | "CATCHUP"
+    | "RECONNECTING"
+    | null;
+export const SyncState = {
     /** Emitted after we try to sync more than `FAILED_SYNC_ERROR_THRESHOLD`
      * times and are still failing. Or when we enounter a hard error like the
      * token being invalid. */
-    Error = "ERROR",
+    Error: "ERROR" as SyncState,
     /** Emitted after the first sync events are ready (this could even be sync
      * events from the cache) */
-    Prepared = "PREPARED",
+    Prepared: "PREPARED" as SyncState,
     /** Emitted when the sync loop is no longer running */
-    Stopped = "STOPPED",
+    Stopped: "STOPPED" as SyncState,
     /** Emitted after each sync request happens */
-    Syncing = "SYNCING",
+    Syncing: "SYNCING" as SyncState,
     /** Emitted after a connectivity error and we're ready to start syncing again */
-    Catchup = "CATCHUP",
+    Catchup: "CATCHUP" as SyncState,
     /** Emitted for each time we try reconnecting. Will switch to `Error` after
      * we reach the `FAILED_SYNC_ERROR_THRESHOLD`
      */
-    Reconnecting = "RECONNECTING",
-}
+    Reconnecting: "RECONNECTING" as SyncState,
+    Null: null as SyncState,
+} as const;
 
 // Room versions where "insertion", "batch", and "marker" events are controlled
 // by power-levels. MSC2716 is supported in existing room versions but they


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist
* [x] Tests written for new code (and old code if feasible) – **I'm considering the type check to be sufficient testing**
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

## Changelog
- Adds `null` as a valid member of `SyncState`, adds `SyncState.Null` enum case

## Why?
Without `strictNullChecks`, TypeScript allows returning `null` from a function which does not have a nullable return type. This is fine by convention within `matrix-js-sdk`, but causes problems when `matrix-js-sdk` is used in a TS project which does have `strictNullChecks`, e.g. I would expect a type error if I forget to check for null in a switch on `SyncState`, but there is none, which may cause an error at runtime. (Turning on `strictNullChecks` is tracked here: https://github.com/matrix-org/matrix-js-sdk/issues/2112)

`SyncState` is one type that is affected by the lack of `strictNullChecks` – it can be null, but TS doesn't "know" that. This PR adds `null` as a subtype of `SyncState`: **in all places where `SyncState` is used, `null` is now accepted / expected by `strictNullChecks` projects.**

Previously:
```ts
// With `strictNullChecks` and exhaustiveness checking e.g. https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.md

// Type
switch (client.getSyncState()) {
  case SyncState.Error: // ...
  case SyncState.Prepared: // ...
  case SyncState.Stopped: // ...
  case SyncState.Syncing: // ...
  case SyncState.Catchup: // ...
  case SyncState.Reconnecting: // ...
}
```

`SyncState` was previously a TypeScript enum with string values for each case. I first tried adding a `Null` case with a value of `null`, but TS does not allow `null` as an enum value.

Instead, I added a union `type` of string literals + `null`, and a `const` object mapping the previous enum tags to each value. **I think this approach adds the `null` case while not breaking backwards compatibility, but I'm not 100% sure.**

Impact to existing code that come to mind:
- Typecheck will be slightly different: e.g. where a `SyncState` is expected, one can use a string literal (`"PREPARED"`) instead of being forced to use the enum syntax (`SyncState.Prepared`). All previous code should continue to work and typecheck as expected.
- TypeScript enums are implemented 