### PR TITLE
Use /v3 as prefix for /refresh

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7063,7 +7063,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             undefined,
             { refresh_token: refreshToken },
             {
-                prefix: PREFIX_V1,
+                prefix: PREFIX_V3,
                 inhibitLogoutEmit: true, // we don't want to cause logout loops
             },
         );


### PR DESCRIPTION
matrix-js-sdk previously used /v1 as prefix for /refresh endpoint. This would work with Synapse v1.71.0 and below, as Synapse had a bug which incorrectly used /v1 for /refresh. After matrix-org/synapse#14364 (which was released in v1.72.0), using /v1 no longer works with Synapse.

This change will break matrix-js-sdk clients which are interfacing with Synapse pre-v1.72.0; but using /v3 is the correct behavior.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
