### PR TITLE
Add `forcePrefixWithV1` option to `MatrixClient#refreshToken`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7052,10 +7052,14 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * unknown by the server - the caller is responsible for managing logout
      * actions on error.
      * @param {string} refreshToken The refresh token.
+     * @param {string} options.forcePrefixV1 If true, uses /v1 instead of the
+     *     specced /v3; useful when targeting Synapse v1.71.0 and below.
      * @return {Promise<IRefreshTokenResponse>} Resolves to the new token.
      * @return {module:http-api.MatrixError} Rejects with an error response.
      */
-    public refreshToken(refreshToken: string): Promise<IRefreshTokenResponse> {
+    public refreshToken(refreshToken: string, options: {
+      forcePrefixV1?: boolean;
+    } = {}): Promise<IRefreshTokenResponse> {
         return this.http.authedRequest(
             undefined,
             Method.Post,
@@ -7063,7 +7067,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             undefined,
             { refresh_token: refreshToken },
             {
-                prefix: PREFIX_V3,
+                prefix: options.forcePrefixV1 ? PREFIX_V1 : PREFIX_V3,
                 inhibitLogoutEmit: true, // we don't want to cause logout loops
             },
         );


### PR DESCRIPTION
For context, see #3. This PR adds an option to `MatrixClient#refreshToken` to help handle servers which use an incorrect prefix for the `/refresh` endpoint (e.g. Synapse before v1.71.0).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
